### PR TITLE
Add package install retries to prevent locking failures.

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -53,6 +53,10 @@
     name: "{{ cwa_dependencies_packages }}"
     state: present
     force: true
+  register: package_ok
+  retries: 5
+  delay: 2
+  until: package_ok is success
   tags:
     - install
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -56,5 +56,9 @@
   yum:
     name: "{{ cwa_temp_path }}/{{ cwa_package }}.rpm"
     state: present
+  register: package_ok
+  retries: 5
+  delay: 2
+  until: package_ok is success
   tags:
     - install


### PR DESCRIPTION
  * yum and apt frequently fail to install because of locking.
  * occurs frequently on our aws packer builds
  * retring is a reasonable approach

Other options are https://github.com/ansible/ansible/issues/57189 but maybe a bit new.