### PR TITLE
Make EPEL Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ cwa_logrotate_file_size: "10M"
 # default value: 5
 cwa_logrotate_files: 5
 ```
+```yaml
+# Do we use the christiangda.epel_repo or manage it ourselves?
+# posible values:
+# default value: true
+cwa_use_epel_role: true
+```
 
 ## Dependencies
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -45,6 +45,7 @@
     - name: Include role christiangda.epel_repo from Galaxy
       include_role:
         name: christiangda.epel_repo
+      when: cwa_use_epel_role == True
     - name: Install "{{ cwa_dependencies_packages }}" dependency
       yum:
         name: "{{ cwa_dependencies_packages }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -29,3 +29,4 @@ cwa_temp_path: /tmp
 cwa_use_credentials: "{{ true|bool if cwa_agent_mode == 'onPremise' else false|bool }}"
 cwa_use_proxy: "{{ true|bool if cwa_http_proxy is defined and cwa_http_proxy|length > 0 else false|bool }}"
 cwa_use_conf_json_template: "{{ false|bool if cwa_conf_json_file_content is defined and cwa_conf_json_file_content|length > 0 else true|bool }}"
+cwa_use_epel_role: true


### PR DESCRIPTION
Many organisations already have a methodology for managing EPEL.

This patch enables you to switch off the `christiangda.epel_repo` if needed so that EPEL is not installed twice.

The *default* is for the `christiangda.epel_repo` role to remain enabled, you *must* disable the role if you don't want to use it.