### PR TITLE
ubuntu: fix gpg signature download

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -29,7 +29,7 @@
 
 - name: Download {{ cwa_package }}.deb file
   get_url:
-    url: "{{ cwa_package_url }}"
+    url: "{{ cwa_package_signature }}"
     dest: "{{ cwa_temp_path }}/{{ cwa_package }}.deb"
     timeout: "{{ cwa_global_downloads_timeout }}"
   tags:

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -40,7 +40,7 @@
 - name: Verify {{ cwa_package }} package signature
   command: gpg --verify {{ cwa_package }}.deb.sig {{ cwa_package }}.deb
   register: verified_sig
-  failed_when: "'BAD' in verified_sig.stderr"
+  failed_when: "'BAD' in verified_sig.stderr or 'gpg: no valid OpenPGP data found' in verified_sig.stderr"
   changed_when: false
   args:
     chdir: "{{ cwa_temp_path }}"


### PR DESCRIPTION
While testing the upgrade from version 1.0.0 I noticed that the signature file had the same size as the package file.

This pull request aims to fix the signature download and additionally adds a check if the gpg signature file does not contain a valid signature

```
fatal: [10.89.1.106]: FAILED! => {
    "changed": false, 
    "cmd": [
        "gpg", 
        "--verify", 
        "amazon-cloudwatch-agent.deb.sig", 
        "amazon-cloudwatch-agent.deb"
    ], 
    "delta": "0:00:00.175088", 
    "end": "2020-02-03 15:15:23.579666", 
    "failed_when_result": true, 
    "invocation": {
        "module_args": {
            "_raw_params": "gpg --verify amazon-cloudwatch-agent.deb.sig amazon-cloudwatch-agent.deb", 
            "_uses_shell": false, 
            "argv": null, 
            "chdir": "/tmp", 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "stdin_add_newline": true, 
            "strip_empty_ends": true, 
            "warn": true
        }
    }, 
    "msg": "non-zero return code", 
    "rc": 2, 
    "start": "2020-02-03 15:15:23.404578", 
    "stderr": "gpg: no valid OpenPGP data found.\ngpg: the signature could not be verified.\nPlease remember that the signature file (.sig or .asc)\nshould be the first file given on the command line.", 
    "stderr_lines": [
        "gpg: no valid OpenPGP data found.", 
        "gpg: the signature could not be verified.", 
        "Please remember that the signature file (.sig or .asc)", 
        "should be the first file given on the command line."
    ], 
    "stdout": "", 
    "stdout_lines": []
}
```