### PR TITLE
fix(readme): use correct config

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ Using INLINE YAML configuration file
                   - sleeping
                   - dead
             append_dimensions:
-              ImageId: "${!aws:ImageId}"
-              InstanceId: "${!aws:InstanceId}"
-              InstanceType: "${!aws:InstanceType}"
-              AutoScalingGroupName: "${!aws:AutoScalingGroupName}"
+              ImageId: "${aws:ImageId}"
+              InstanceId: "${aws:InstanceId}"
+              InstanceType: "${aws:InstanceType}"
+              AutoScalingGroupName: "${aws:AutoScalingGroupName}"
             aggregation_dimensions:
               - - AutoScalingGroupName
               - - InstanceId


### PR DESCRIPTION
AWS probably just updated it, I don't know. They mentioned here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html that you should use {aws:XYZ} instead of {!aws:XYZ}.