### PR TITLE
Add support for Graviton ARM64 processors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,3 +108,8 @@ cwa_logrotate_file_size: "10M"
 # - https://linux.die.net/man/8/logrotate
 # default value: 5
 cwa_logrotate_files: 5
+
+cwa_arch_names: {
+  "x86_64": "amd64",
+  "aarch64": "arm64"
+}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,10 @@
 # - name: check ansible_virtualization_type
 #   debug: msg="ansible_virtualization_type = {{ ansible_virtualization_type }}"
 
+- name: Set AWS architecture name
+  set_fact:
+    cwa_arch_name: "{{ cwa_arch_names.get(ansible_architecture) }}"
+
 # Selective include of vars
 - name: Include variables for RHEL
   include_vars: "{{ item }}"

--- a/vars/amazon.yml
+++ b/vars/amazon.yml
@@ -1,3 +1,3 @@
 ---
-cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
-cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm.sig
+cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.rpm
+cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.rpm.sig

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -1,3 +1,3 @@
 ---
-cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm
-cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm.sig
+cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/centos/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.rpm
+cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/centos/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.rpm.sig

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,6 +1,6 @@
 ---
-cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
-cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb.sig
+cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/debian/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.deb
+cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/debian/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.deb.sig
 
 cwa_gpg_dependencies_packages:
   - gpg

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,3 @@
 ---
-cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
-cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm.sig
+cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.rpm
+cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.rpm.sig

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,6 +1,6 @@
 ---
-cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
-cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb.sig
+cwa_package_url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.deb
+cwa_package_signature: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/{{ cwa_arch_name }}/latest/amazon-cloudwatch-agent.deb.sig
 
 cwa_gpg_dependencies_packages:
   - gpg


### PR DESCRIPTION
This should positively address the question raised in issue #36. It checks the CPU architecture as reported by ansible and uses that to determine the package and signature urls. It's working for me on a t4g instance.