### PR TITLE
Fall back to main distribution vars file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
   include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution|lower }}.yml"
     - "main.yml"
   when: >
     ansible_os_family == 'RedHat' or ansible_os_family == 'Debian'


### PR DESCRIPTION
This fixes an issue on Ubuntu 22 when using this role that it couldn't find the proper variables file and failed on not having `cwa_gpg_dependencies_packages` variable set.