### PR TITLE
Fix running only specific tags

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,8 @@
 - name: Set architecture name
   set_fact:
     cwa_arch_name: "{{ cwa_arch_names.get(ansible_architecture) }}"
+  tags:
+    - include-vars
 
 # Include of vars
 - name: Include variables for {{ ansible_distribution | lower }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 
 # Installation tasks
 - name: Include tasks for installation on {{ ansible_os_family | lower }} distribution
-  include_tasks: "install-{{ ansible_os_family | lower }}.yml"
+  import_tasks: "install-{{ ansible_os_family | lower }}.yml"
   when: >
     ansible_os_family == 'RedHat' or ansible_os_family == 'Debian'
   tags:
@@ -50,6 +50,6 @@
 
 # Configuration tasks
 - name: Configure {{ cwa_package }} for {{ ansible_distribution | lower }}
-  include_tasks: "configure.yml"
+  import_tasks: "configure.yml"
   tags:
     - configure


### PR DESCRIPTION
Settings tags on import_tasks will apply them to all imported tasks while include_tasks adds the tag only to the include task itself.
This means using --tags configure will run only the include_task itself but will skip all imported tasks because they don't have the tag.
